### PR TITLE
Fix separator on @3x resolution screens

### DIFF
--- a/SimpleStepper.js
+++ b/SimpleStepper.js
@@ -243,7 +243,7 @@ var styles = StyleSheet.create({
   },
   rightButton: {
     alignItems: "center",
-    borderWidth: 0.5,
+    borderWidth: StyleSheet.hairlineWidth,
     borderBottomWidth: 0,
     borderTopWidth: 0,
     borderRightWidth: 0


### PR DESCRIPTION
This patch fixes the separator on iOS display with @3x resolutions (iPhone 6 Plus and 6s Plus).

Before, on @3x screens:
![capture d ecran 2017-05-19 a 17 45 40](https://cloud.githubusercontent.com/assets/13909/26299846/9275ecd4-3edc-11e7-81b7-0fa9c83f76c4.png)

After, on @3x screens:
![capture d ecran 2017-05-22 a 11 00 08](https://cloud.githubusercontent.com/assets/13909/26300694/26a59aba-3edf-11e7-919a-f31023c80f82.png)

After, on @2x screens:
![capture d ecran 2017-05-22 a 10 59 28](https://cloud.githubusercontent.com/assets/13909/26300699/2c8fdc6a-3edf-11e7-9f10-37252ded1245.png)
