### PR TITLE
Migrate React.PropTypes to prop-types

### DIFF
--- a/SimpleStepper.js
+++ b/SimpleStepper.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import {PropTypes} from 'prop-types';
 import {StyleSheet, Text, TouchableOpacity, Image, View} from 'react-native';
 
 export default class SimpleStepper extends Component {

--- a/package.json
+++ b/package.json
@@ -44,5 +44,8 @@
     "react-dom": "^15.5.4",
     "react-native": "^0.41.2",
     "react-test-renderer": "^15.4.2"
+  },
+  "dependencies": {
+    "prop-types": "^15.5.10"
   }
 }


### PR DESCRIPTION
React 0.15.5 deprecated `React.PropTypes` and will be removed completely in a newer version of react. Since react-native@0.45, this now shows as an error when the apps are running. https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#new-deprecation-warnings

The React team has provided a drop-in replacement for `React.PropTypes` as a separate library called "prop-types".

This PR replaces `React.PropTypes` with `prop-types`